### PR TITLE
Movefile

### DIFF
--- a/src/Projekt/Args.fs
+++ b/src/Projekt/Args.fs
@@ -4,12 +4,15 @@ open Projekt.Types
 open System.IO
 open Nessos.UnionArgParser
 
+exception private ArgParseError of string
+
 type private Args =
     | Template of string
     | FrameworkVersion of string
-    | Direction of int
+    | Direction of string
     | Repeat of int
     | Link of string
+    | Compile
 with
     interface IArgParserTemplate with
         member s.Usage = 
@@ -19,13 +22,20 @@ with
             | Repeat _ -> "repeat"
             | FrameworkVersion _ -> "fxversion"
             | Link _ -> "link"
+            | Compile _ -> "compile"
 
 let private templateArg (res : ArgParseResults<Args>) =
     match res.TryGetResult(<@ Template @>) with
     | Some (ToLower "console") -> Console
     | Some (ToLower "library") -> Library
     | None -> Library
-    | _ -> failwith "invalid template argument specified"
+    | _ -> raise (ArgParseError "invalid template argument specified")
+
+let private parseDirection s =
+    match s with
+    | ToLower "up" -> Up
+    | ToLower "down" -> Down
+    | _ -> raise (ArgParseError "invalid direction specified")
 
 let private parser = UnionArgParser.Create<Args>()
 
@@ -45,14 +55,35 @@ let split (args : string list) =
 
 let parse (ToList args) : Result<Operation> =
     let required, _ = split args
-    match required with
-    | ToLower "init" :: FullPath path :: Options opts -> 
-        let template = templateArg opts
-        Init (ProjectInitData.create (path, template)) |> Success
-    | ToLower "addfile" :: FullPath project :: FullPath file :: Options opts -> 
-        AddFile ({ ProjPath = project; FilePath = file }, Types.Link (opts.TryGetResult <@ Link @>)) |> Success
-    | [ToLower "delfile"; FullPath project; FullPath file] -> 
-        DelFile { ProjPath = project; FilePath = file } |> Success
-    | [ToLower "reference"; FullPath project; FullPath reference] -> 
-        Reference { ProjPath = project; Reference = reference } |> Success
-    | _ -> Failure (sprintf "err: could not parse %A as an implemented command" args)
+    try
+        match required with
+        | ToLower "init" :: FullPath path :: Options opts -> 
+            let template = templateArg opts
+            Init (ProjectInitData.create (path, template)) |> Success
+            
+        | ToLower "addfile" :: FullPath project :: FullPath file :: Options opts -> 
+            AddFile { ProjPath = project
+                      FilePath = file
+                      Link = opts.TryGetResult <@ Link @>
+                      Compile = opts.Contains <@ Compile @>}
+            |> Success
+            
+        | [ToLower "delfile"; FullPath project; FullPath file] -> 
+            DelFile { ProjPath = project; FilePath = file }
+            |> Success
+            
+        | ToLower "movefile" :: FullPath project :: FullPath file :: Options opts
+                when opts.Contains <@ Direction @> ->
+                  
+            let direction = opts.PostProcessResult(<@ Direction @>, parseDirection)
+            MoveFile { ProjPath = project
+                       FilePath = file
+                       Direction = direction
+                       Repeat = opts.GetResult(<@ Repeat @>, 1)}
+            |> Success
+            
+        | [ToLower "reference"; FullPath project; FullPath reference] -> 
+            Reference { ProjPath = project; Reference = reference } |> Success
+        | _ -> Failure (sprintf "err: could not parse %A as an implemented command" args)
+    with
+      | ArgParseError s -> Failure s

--- a/src/Projekt/Main.fs
+++ b/src/Projekt/Main.fs
@@ -58,12 +58,17 @@ let main argv =
         | Failure msg ->
             eprintfn "%s" msg
             1
-    | AddFile (data, Link link) ->
-        Project.addFile data.ProjPath data.FilePath link
+    | AddFile data ->
+        Project.addFile data.ProjPath data.FilePath data.Link data.Compile
         |> saveOrPrintError data.ProjPath
     | DelFile data ->
-        saveOrPrintError data.ProjPath
-                         (Project.delFile data.ProjPath data.FilePath)
+        (Project.delFile data.ProjPath data.FilePath)
+        |> saveOrPrintError data.ProjPath
+
+    | MoveFile data ->
+        (Project.moveFile data.ProjPath data.FilePath data.Direction data.Repeat)
+        |> saveOrPrintError data.ProjPath
+        
     | Reference { ProjPath = path; Reference = reference } ->
         Project.addReference path reference
         |> saveOrPrintError path 

--- a/src/Projekt/Main.fs
+++ b/src/Projekt/Main.fs
@@ -1,41 +1,15 @@
 module Projekt.Main
 open System.Xml.Linq
-
-let help = """
-projekt (init|reference|newfile|addfile|renamefile) /path/to/project {--template=(library|console)} {--solution=path/to/sln} --direction=(down|up) --repeat={int} --frameworkversion=(4.0|4.5|4.5.1)
-
---solution - when specificed add remove 
---direction - for move operations
---frameworkversion
---n - repeat action n times - ony works for move operations
---compile=(true|false) - when adding file this flag allows you to exclude it from compilation
-
-examples:
-
-projekt init /path/to/new/fsproj --template=library //creates a new project but does not add it to a solution
-
-projekt reference /path/to/target {thingtoreference} //references project or binary
-
-projekt addfile /path/to/project /path/to/file [--link] //add file to project (create if not exists) - could template files?
-
-projekt delfile /path/to/project /path/to/file //delete file from project
-
-projekt movefile /path/to/project --direction=up --n=3 //adjust file position
-
-"""
-
 open System
-
-
 
 [<EntryPoint>]
 let main argv =
     let op = 
         match Args.parse argv with
-        | Success op -> op
+        | Success op -> printfn "%A" op; exit 1
         | Failure msg ->
             eprintfn "%s" msg
-            Help
+            Exit
 
     let save (el : XElement) (path: string) =
         try
@@ -73,6 +47,5 @@ let main argv =
         Project.addReference path reference
         |> saveOrPrintError path 
     | _ -> 
-        printfn "%s" help
         1
 

--- a/src/Projekt/Types.fs
+++ b/src/Projekt/Types.fs
@@ -58,7 +58,7 @@ type Operation =
     | AddFile of AddFileData
     | DelFile of DelFileData
     | MoveFile of MoveFileData
-    | Help
+    | Exit
 
 type Result<'a> =
     | Success of 'a

--- a/src/Projekt/Types.fs
+++ b/src/Projekt/Types.fs
@@ -9,10 +9,6 @@ type Direction =
     | Up
     | Down
 
-type Repeat = | Repeat of int
-
-type Link = | Link of Option<string>
-
 type FrameworkVersion =
     | V4_0
     | V4_5
@@ -40,16 +36,28 @@ type ProjectReferenceData =
     { ProjPath: string
       Reference: string }
 
-type FileData =
+type AddFileData =
+    { ProjPath: string
+      FilePath: string
+      Link: Option<string>
+      Compile: bool }
+    
+type DelFileData =
     { ProjPath: string
       FilePath: string }
+
+type MoveFileData =
+    { ProjPath: string
+      FilePath: string
+      Direction: Direction
+      Repeat: int }
 
 type Operation =
     | Init of ProjectInitData //project path 
     | Reference of ProjectReferenceData
-    | AddFile of FileData * Link
-    | DelFile of FileData
-    | MoveFile of FileData * Direction * Repeat
+    | AddFile of AddFileData
+    | DelFile of DelFileData
+    | MoveFile of MoveFileData
     | Help
 
 type Result<'a> =

--- a/tests/Projekt.Tests/Tests.fs
+++ b/tests/Projekt.Tests/Tests.fs
@@ -7,6 +7,11 @@ open NUnit.Framework
 open Projekt.Util
 open FsUnit
 
+let assertDeepEquals expected result =
+  Assert.IsTrue (XNode.DeepEquals(expected, result),
+                 "Expected: {0}, result: {1}", expected, result)
+
+
 let baseXml = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
@@ -45,8 +50,7 @@ let ``addProjRefNode should append an ItemGroup if none found`` () =
     let guid = Guid.Parse "{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}"
     let sut = XElement.Parse baseXml
     let (Success result) = Project.addProjRefNode "../../src/Test/Test.fsproj" "Test" guid sut
-    XNode.DeepEquals(expected, result)
-    |> Assert.IsTrue
+    assertDeepEquals expected result
 
 [<Test>] 
 let ``addProjRefNode should append a ProjectReference if one already exists`` () =
@@ -75,8 +79,7 @@ let ``addProjRefNode should append a ProjectReference if one already exists`` ()
     let guid = Guid.Parse "{ceb3e6b3-c06f-4a24-82e6-9e70ba4adfe8}"
     let sut = XElement.Parse singleIGandTestRef
     let (Success result) = Project.addProjRefNode "../../src/Test2/Test2.fsproj" "Test2" guid sut
-    XNode.DeepEquals(expected, result)
-    |> Assert.IsTrue
+    assertDeepEquals expected result
 
 [<Test>] 
 let ``addProjRefNode should be idempotent`` () =
@@ -84,25 +87,33 @@ let ``addProjRefNode should be idempotent`` () =
     let sut = XElement.Parse singleIGandTestRef 
     let guid = Guid.Parse "{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}"
     let (Success result) = Project.addProjRefNode "../../src/Test/Test.fsproj" "Test" guid sut
-    XNode.DeepEquals(expected, result)
-    |> Assert.IsTrue
+    assertDeepEquals expected result
 
 [<Test>]
 let ``addFile should add the file if not present`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/data/Tests.fs"
-    match Project.addFile projFile srcFile None with
+    match Project.addFile projFile srcFile None true with
     | Failure s -> Assert.Fail s
     | Success result ->
         let expected = XElement.Load (__SOURCE_DIRECTORY__ + "/data/AddFile-expected.fsproj")
-        XNode.DeepEquals(expected, result)
-        |> Assert.IsTrue
+        assertDeepEquals expected result
+
+[<Test>]
+let ``addFile should use None if requested`` () =
+    let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-None-input.fsproj"
+    let srcFile = __SOURCE_DIRECTORY__ + "/data/Tests.fs"
+    match Project.addFile projFile srcFile None false with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        let expected = XElement.Load (__SOURCE_DIRECTORY__ + "/data/AddFile-None-expected.fsproj")
+        assertDeepEquals expected result
 
 [<Test>]
 let ``addFile should create the file if it doesn't exist`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/data/Newfile.fs"
-    match Project.addFile projFile srcFile None with
+    match Project.addFile projFile srcFile None true with
     | Failure s -> Assert.Fail s
     | Success result ->
         Assert.That(File.Exists srcFile, "File should exist: " + srcFile)
@@ -112,18 +123,17 @@ let ``addFile should create the file if it doesn't exist`` () =
 let ``addFile should create an item group if not present`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-NoItemGroup-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/data/Tests.fs"
-    match Project.addFile projFile srcFile None with
+    match Project.addFile projFile srcFile None true with
     | Failure s -> Assert.Fail s
     | Success result ->
         let expected = XElement.Load (__SOURCE_DIRECTORY__ + "/data/AddFile-NoItemGroup-expected.fsproj")
-        XNode.DeepEquals(expected, result)
-        |> Assert.IsTrue
+        assertDeepEquals expected result
 
 [<Test>]
 let ``addFile should fail if file in project`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-AlreadyPresent-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/data/Tests.fs"
-    match Project.addFile projFile srcFile None with
+    match Project.addFile projFile srcFile None true with
     | Failure s -> s |> should endWith "already exists in project."
     | Success result -> Assert.Fail()
 
@@ -131,7 +141,7 @@ let ``addFile should fail if file in project`` () =
 let ``addFile should fail if trying to copy and already on disk`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/Tests.fs"
-    match Project.addFile projFile srcFile None with
+    match Project.addFile projFile srcFile None true with
     | Failure s -> s |> should endWith "already present."
     | Success result -> Assert.Fail()
 
@@ -139,7 +149,7 @@ let ``addFile should fail if trying to copy and already on disk`` () =
 let ``addFile should fail if trying to copy and doesn't exist`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/FileThatWillHopefullyNeverExist"
-    match Project.addFile projFile srcFile None with
+    match Project.addFile projFile srcFile None true with
     | Failure s -> s |> should endWith "not found."
     | Success result -> Assert.Fail()
 
@@ -147,29 +157,27 @@ let ``addFile should fail if trying to copy and doesn't exist`` () =
 let ``addFile should add next to a None Include if no Compile Include`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-OnlyNone-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/data/Tests.fs"
-    match Project.addFile projFile srcFile None with
+    match Project.addFile projFile srcFile None true with
     | Failure s -> Assert.Fail s
     | Success result ->
         let expected = XElement.Load (__SOURCE_DIRECTORY__ + "/data/AddFile-OnlyNone-expected.fsproj")
-        XNode.DeepEquals(expected, result)
-        |> Assert.IsTrue
+        assertDeepEquals expected result
 
 [<Test>]
 let ``addFile should insert the link`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-Link-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/Tests.fs"
-    match Project.addFile projFile srcFile (Some "foldername/Tests.fs") with
+    match Project.addFile projFile srcFile (Some "foldername/Tests.fs") true with
     | Failure s -> Assert.Fail s
     | Success result ->
         let expected = XElement.Load (__SOURCE_DIRECTORY__ + "/data/AddFile-Link-expected.fsproj")
-        XNode.DeepEquals(expected, result)
-        |> Assert.IsTrue
+        assertDeepEquals expected result
     
 [<Test>]
 let ``addFile followed by delFile should be identity`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-input.fsproj"
     let srcFile = __SOURCE_DIRECTORY__ + "/data/Tests.fs"
-    match Project.addFile projFile srcFile None with
+    match Project.addFile projFile srcFile None true with
     | Failure s -> Assert.Fail s
     | Success p ->
         let tmpFile = __SOURCE_DIRECTORY__ + "/data/" + Path.GetRandomFileName()
@@ -179,8 +187,7 @@ let ``addFile followed by delFile should be identity`` () =
             | Failure s -> Assert.Fail s
             | Success result ->
                 let expected = XElement.Load (__SOURCE_DIRECTORY__ + "/data/AddFile-input.fsproj")
-                XNode.DeepEquals(expected, result)
-                |> Assert.IsTrue
+                assertDeepEquals expected result
         finally
             File.Delete tmpFile
 
@@ -216,6 +223,142 @@ let ``delFile should remove file if present`` () =
     | Failure s -> Assert.Fail s
     | Success result ->
         let expected = XElement.Parse delExpected
-        XNode.DeepEquals(expected, result)
+        assertDeepEquals expected result
+
+[<Test>]
+let ``moveFile up with 0 is identity`` () =
+    let proj = XElement.Parse delInput
+    match Project.moveFileNodePosition proj "Tests.fs" Up 0 with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        XNode.DeepEquals(proj, result)
         |> Assert.IsTrue
-    
+
+[<Test>]
+let ``moveFile down with 0 is identity`` () =
+    let proj = XElement.Parse delInput
+    match Project.moveFileNodePosition proj "Tests.fs" Down 0 with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        XNode.DeepEquals(proj, result)
+        |> Assert.IsTrue
+
+let moveInput = """<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="File1.fs" />
+    <Compile Include="File2.fs" />
+    <None Include="File3.fs" />
+    <Compile Include="File4.fs" />
+    <Compile Include="File5.fs" />
+    <Compile Include="File6.fs" />
+  </ItemGroup>
+</Project>
+"""
+
+[<Test>]
+let ``moveFile up 1 compile file`` () =
+    let proj = XElement.Parse moveInput
+    match Project.moveFileNodePosition proj "File2.fs" Up 1 with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        let expected = XElement.Parse """<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="File2.fs" />
+    <Compile Include="File1.fs" />
+    <None Include="File3.fs" />
+    <Compile Include="File4.fs" />
+    <Compile Include="File5.fs" />
+    <Compile Include="File6.fs" />
+  </ItemGroup>
+</Project>
+"""
+        assertDeepEquals expected result
+
+[<Test>]
+let ``moveFile up 2 none file`` () =
+    let proj = XElement.Parse moveInput
+    match Project.moveFileNodePosition proj "File3.fs" Up 2 with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        let expected = XElement.Parse """<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <None Include="File3.fs" />
+    <Compile Include="File1.fs" />
+    <Compile Include="File2.fs" />
+    <Compile Include="File4.fs" />
+    <Compile Include="File5.fs" />
+    <Compile Include="File6.fs" />
+  </ItemGroup>
+</Project>
+"""
+        assertDeepEquals expected result
+
+[<Test>]
+let ``moveFile up past end should stop at top`` () =
+    let proj = XElement.Parse moveInput
+    match Project.moveFileNodePosition proj "File3.fs" Up 5 with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        let expected = XElement.Parse """<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <None Include="File3.fs" />
+    <Compile Include="File1.fs" />
+    <Compile Include="File2.fs" />
+    <Compile Include="File4.fs" />
+    <Compile Include="File5.fs" />
+    <Compile Include="File6.fs" />
+  </ItemGroup>
+</Project>
+"""
+        assertDeepEquals expected result
+
+[<Test>]
+let ``moveFile missing file should fail`` () =
+    let proj = XElement.Parse moveInput
+    match Project.moveFileNodePosition proj "NotThere.fs" Up 5 with
+    | Failure s -> s |> should endWith "not found in project."
+    | Success _ -> Assert.Fail()
+
+[<Test>]
+let ``moveFile down past end should stop at bottom`` () =
+    let proj = XElement.Parse moveInput
+    match Project.moveFileNodePosition proj "File3.fs" Down 5 with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        let expected = XElement.Parse """<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="File1.fs" />
+    <Compile Include="File2.fs" />
+    <Compile Include="File4.fs" />
+    <Compile Include="File5.fs" />
+    <Compile Include="File6.fs" />
+    <None Include="File3.fs" />
+  </ItemGroup>
+</Project>
+"""
+        assertDeepEquals expected result
+
+[<Test>]
+let ``moveFile down 2`` () =
+    let proj = XElement.Parse moveInput
+    match Project.moveFileNodePosition proj "File1.fs" Down 2 with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        let expected = XElement.Parse """<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="File2.fs" />
+    <None Include="File3.fs" />
+    <Compile Include="File1.fs" />
+    <Compile Include="File4.fs" />
+    <Compile Include="File5.fs" />
+    <Compile Include="File6.fs" />
+  </ItemGroup>
+</Project>
+"""
+        assertDeepEquals expected result

--- a/tests/Projekt.Tests/data/AddFile-None-expected.fsproj
+++ b/tests/Projekt.Tests/data/AddFile-None-expected.fsproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <ProjectGuid>165a6853-05ed-4f03-a7b1-1c84d4f01bf5</ProjectGuid>
+    <RootNamespace>Projekt</RootNamespace>
+    <AssemblyName>Projekt</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.fs" />
+    <None Include="paket.template" />
+    <None Include="Tests.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+      <Paket>True</Paket>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/tests/Projekt.Tests/data/AddFile-None-input.fsproj
+++ b/tests/Projekt.Tests/data/AddFile-None-input.fsproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <ProjectGuid>165a6853-05ed-4f03-a7b1-1c84d4f01bf5</ProjectGuid>
+    <RootNamespace>Projekt</RootNamespace>
+    <AssemblyName>Projekt</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.fs" />
+    <None Include="paket.template" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+      <Paket>True</Paket>
+    </Reference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This adds the movefile command, and addfile understands --compile.

I ran into some issues with the command line parser so I've tided it up a bit. I don't think that it is working that well with our structure of different commands though. Perhaps we should have a two-level structure where the first level parses the command and then the second level uses a different UnionArgParser for each command (as they usually have different options). I'm not sure of the best approach.
