### PR TITLE
Use FAKE assemblyfileinfo helper

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -82,7 +82,8 @@ Target "AssemblyInfo" (fun _ ->
           Attribute.Product project
           Attribute.Description summary
           Attribute.Version release.AssemblyVersion
-          Attribute.FileVersion release.AssemblyVersion ]
+          Attribute.FileVersion release.AssemblyVersion
+          Attribute.InternalsVisibleTo "Projekt.Tests" ]
 
     let getProjectDetails projectPath =
         let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath)
@@ -338,7 +339,7 @@ Target "BuildPackage" DoNothing
 Target "All" DoNothing
 
 "Clean"
-//  ==> "AssemblyInfo"
+  ==> "AssemblyInfo"
   ==> "Build"
   ==> "CopyBinaries"
   ==> "RunTests"

--- a/src/Projekt/Args.fs
+++ b/src/Projekt/Args.fs
@@ -57,7 +57,7 @@ let (|FullPath|_|) (path : string) =
     with
     | _ -> None
 
-let commandUsage = "projekt (init|reference|newfile|addfile|delfile) /path/to/project [/path/to/(file|project)]"
+let commandUsage = "projekt (init|reference|newfile|addfile|delfile|version) /path/to/project [/path/to/(file|project)]"
 
 let parse (ToList args) : Result<Operation> =
     try
@@ -65,6 +65,9 @@ let parse (ToList args) : Result<Operation> =
         | [] -> 
             parser.Usage commandUsage 
             |> Failure
+
+        | ToLower "version" :: _ ->
+            Success Version
 
         | ToLower "init" :: FullPath path :: Options opts -> 
             let template = templateArg opts

--- a/src/Projekt/AssemblyInfo.fs
+++ b/src/Projekt/AssemblyInfo.fs
@@ -2,12 +2,12 @@
 open System.Reflection
 open System.Runtime.CompilerServices
 
-[<assembly: InternalsVisibleToAttribute("Projekt.Tests")>]
 [<assembly: AssemblyTitleAttribute("Projekt")>]
 [<assembly: AssemblyProductAttribute("Projekt")>]
 [<assembly: AssemblyDescriptionAttribute("A command line tool for creating and updating F# project files")>]
 [<assembly: AssemblyVersionAttribute("0.0.1")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.1")>]
+[<assembly: InternalsVisibleToAttribute("Projekt.Tests")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Projekt/Main.fs
+++ b/src/Projekt/Main.fs
@@ -46,7 +46,12 @@ let main argv =
         
     | Reference { ProjPath = path; Reference = reference } ->
         Project.addReference path reference
-        |> saveOrPrintError path 
+        |> saveOrPrintError path
+
+    | Version ->
+        printfn "projekt %s" AssemblyVersionInformation.Version
+        0
+          
     | _ -> 
         1
 

--- a/src/Projekt/Types.fs
+++ b/src/Projekt/Types.fs
@@ -59,6 +59,7 @@ type Operation =
     | DelFile of DelFileData
     | MoveFile of MoveFileData
     | Exit
+    | Version
 
 type Result<'a> =
     | Success of 'a


### PR DESCRIPTION
It now includes the InternalsVisibleTo for Projekt.Tests. Exposed via a
'version' command. We can now use RELEASE_NOTES.md and have the top
header automatically used to inject the version number.
