### PR TITLE
Address #27 from fsprojects/Projekt

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -90,7 +90,8 @@ Target "AssemblyInfo" (fun _ ->
           Attribute.Description summary
           Attribute.Version release.AssemblyVersion
           Attribute.FileVersion release.AssemblyVersion
-          Attribute.InternalsVisibleTo "Projekt.Tests" ]
+          Attribute.InternalsVisibleTo "Projekt.Tests"
+          Attribute.Company "fsprojects" ]
 
     let getProjectDetails projectPath =
         let projectName = System.IO.Path.GetFileNameWithoutExtension(projectPath)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,5 +7,6 @@ nuget NUnit.Runners
 nuget FAKE
 nuget SourceLink.Fake
 nuget UnionArgParser
+nuget CommandLineParser prerelease
 
 github fsharp/FAKE modules/Octokit/Octokit.fsx

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,6 @@ nuget NUnit
 nuget NUnit.Runners
 nuget FAKE
 nuget SourceLink.Fake
-nuget UnionArgParser
 nuget CommandLineParser prerelease
 
 github fsharp/FAKE modules/Octokit/Octokit.fsx

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,7 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
+    CommandLineParser (2.0.99-alpha)
     FAKE (3.35.2)
     FSharp.Compiler.Service (0.0.90)
     FSharp.Formatting (2.9.9)
@@ -25,5 +26,5 @@ NUGET
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (38dcc9d8c61d6868601fe848d8eff765e74935f0)
+    modules/Octokit/Octokit.fsx (8b027106c29c4e05f30fe0dc3dbf6332293e05fa)
       Octokit

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    CommandLineParser (2.0.99-alpha)
+    CommandLineParser (2.0.223-beta)
     FAKE (3.35.2)
     FSharp.Compiler.Service (0.0.90)
     FSharp.Formatting (2.9.9)
@@ -22,9 +22,8 @@ NUGET
     Octokit (0.13.0)
       Microsoft.Net.Http
     SourceLink.Fake (0.5.0)
-    UnionArgParser (0.8.7)
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (8b027106c29c4e05f30fe0dc3dbf6332293e05fa)
+    modules/Octokit/Octokit.fsx (f8684a9a3ccd1e0e78b77925a2aa2c259f6787dc)
       Octokit

--- a/src/Projekt/Args.fs
+++ b/src/Projekt/Args.fs
@@ -2,183 +2,89 @@ module Projekt.Args
 
 open Projekt.Types
 
-module NewArgs =
+module Args =
     open CommandLine
 
     [<Verb("init", HelpText = "create a new project")>]
-    type public InitOptions = {
-        [<Value(0, Required = true)>]   path : string 
-        [<Option(Default = "library")>] template : string
-        [<Option(Default = "4.5")>]       frameworkVersion : string
-        [<Option>]                      organization : string option
-    }
+    type public InitOptions = 
+        {   [<Value(0, Required = true, MetaName = "project path")>]    path : string 
+            [<Option(Default = "library")>]                             template : string
+            [<Option(Default = "4.5")>]                                 frameworkVersion : string
+            [<Option>]                                                  organization : string option    }
     with 
         member x.ToOperation =
             match x.path with
             | FullPath p -> 
-                ProjectInitData.create p (x.template |> Some |> Template.Create |> Some) (x.frameworkVersion |> Some |> FrameworkVersion.Create |> Some) x.organization
-                |> Init
+                let template = x.template |> Template.Create |> Some
+                let frmwkVersion = x.frameworkVersion |> FrameworkVersion.Create |> Some
+                (ProjectInitData.create 
+                    p 
+                    template
+                    frmwkVersion
+                    x.organization) |> Init
+
             | _ -> failwith "not given a full path"
 
     [<Verb("reference", HelpText = "reference a dll")>]
-    type public ReferenceOptions = {
-        [<Value(0, Required = true)>]   projectPath : string
-        [<Value(1, Required = true)>]   referencePath : string
-    }
+    type public ReferenceOptions = 
+        {   [<Value(0, Required = true, MetaName = "project path")>]    projectPath : string
+            [<Value(1, Required = true, MetaName = "reference path")>]  referencePath : string  }
     with 
         member x.ToOperation =
             match x.projectPath, x.referencePath with
-            | FullPath project, FullPath reference -> {ProjPath = project; Reference = reference} |> Reference
+            | FullPath project, FullPath reference ->
+                {ProjPath = project; Reference = reference} |> Reference
             | _,_ -> failwith "one or both paths were invalid"
 
     [<Verb("movefile", HelpText = "Move a file within a project")>]
-    type public MoveFileOptions = {
-        [<Value(0, Required = true)>]   projectPath : string
-        [<Value(1, Required = true)>]   filePath : string
-        [<Option(Required = true)>]     direction : string
-        [<Option(Default = 1)>]         repeat : int
-    }
+    type public MoveFileOptions = 
+        {   [<Value(0, Required = true, MetaName = "project path")>]    projectPath : string
+            [<Value(1, Required = true, MetaName = "file path")>]       filePath : string
+            [<Option(Required = true)>]                                 direction : string
+            [<Option(Default = 1)>]                                     repeat : int    }
     with
         member x.ToOperation =
             match x.projectPath, x.filePath, Direction.Create x.direction with
-            | FullPath project, FullPath file, dir -> {ProjPath = project; FilePath = file; Direction = dir; Repeat = x.repeat} |> MoveFile
+            | FullPath project, FullPath file, dir -> 
+                {ProjPath = project; FilePath = file; Direction = dir; Repeat = x.repeat} |> MoveFile
             | _,_,_ -> failwith "invalid paths or direction"
 
     [<Verb("addfile", HelpText = "Add a file to a project")>]
-    type public AddFileOptions = {
-        [<Value(0, Required = true)>]   projectPath : string
-        [<Value(1, Required = true)>]   filePath : string
-        [<Option>]                      link : string option
-        [<Option(Default = true)>]      compile : bool 
-    }
+    type public AddFileOptions = 
+        {   [<Value(0, Required = true, MetaName = "project path")>]    projectPath : string
+            [<Value(1, Required = true, MetaName = "file path")>]       filePath : string
+            [<Option>]                                                  link : string option
+            [<Option(Default = true)>]                                  compile : bool  }
     with 
         member x.ToOperation =
             match x.projectPath, x.filePath with
-            | FullPath project, FullPath file -> {ProjPath = project; FilePath = file; Link = x.link; Compile = x.compile} |> AddFile 
+            | FullPath project, FullPath file -> 
+                {ProjPath = project; FilePath = file; Link = x.link; Compile = x.compile} |> AddFile 
             | _,_ -> failwith "invalid paths"
 
     [<Verb("delfile", HelpText = "Delete a file from a project")>]
-    type public DelFileOptions = {
-        [<Value(0, Required = true)>]   projectPath : string
-        [<Value(1, Required = true)>]   filePath : string
-    }
+    type public DelFileOptions = 
+        {   [<Value(0, Required = true, MetaName = "project path")>]    projectPath : string
+            [<Value(1, Required = true, MetaName = "file path")>]       filePath : string   }
     with
         member x.ToOperation =
             match x.projectPath, x.filePath with
-            | FullPath project, FullPath file -> ({ProjPath = project; FilePath = file} : DelFileData) |> DelFile
+            | FullPath project, FullPath file -> 
+                // typing needed here because of the duplication between MoveFileData and DelFileData records
+                // TODO: maybe consolidate?
+                ({ProjPath = project; FilePath = file} : DelFileData) |> DelFile 
             | _,_ -> failwith "invalid paths"
 
-    [<Verb("version", HelpText = "Print out the version of this tool")>]
-    type public VersionOptions = {
-        [<Option>] noArg : string option
-    }
-    with 
-        member x.ToOperation = Version
-
     let parse args = 
-        let parsed = CommandLine.Parser.Default.ParseArguments<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions, VersionOptions>(args)
+        let parsed = CommandLine.Parser.Default.ParseArguments<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions>(args)
         // tried to get fancy here with a statically resolved type param to invoke the ToOperation member on the individal option cases, but I couldn't get it to work....
 
-        result {
-                return 
-                    parsed.Return<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions, VersionOptions, Operation>(
-                        (fun (init : InitOptions) -> init.ToOperation), 
-                        (fun (ref : ReferenceOptions) -> ref.ToOperation), 
-                        (fun (mv : MoveFileOptions) -> mv.ToOperation), 
-                        (fun (add : AddFileOptions) -> add.ToOperation), 
-                        (fun (del : DelFileOptions) -> del.ToOperation), 
-                        (fun (ver : VersionOptions) -> ver.ToOperation), 
-                        (fun errs -> printfn "%A" errs; Operation.Exit)
-                    )
-        }
+        parsed.Return<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions, Result<Operation>>(
+            (fun (init : InitOptions) -> init.ToOperation |> Success), 
+            (fun (ref : ReferenceOptions) -> ref.ToOperation |> Success), 
+            (fun (mv : MoveFileOptions) -> mv.ToOperation |> Success), 
+            (fun (add : AddFileOptions) -> add.ToOperation |> Success), 
+            (fun (del : DelFileOptions) -> del.ToOperation |> Success), 
+            (fun errs -> errs |> Seq.map (fun e -> e.ToString()) |> String.concat ";" |> Failure)
+        )
         
-
-module OldArgs =
-    open Nessos.UnionArgParser
-
-    let commandUsage = "projekt (init|reference|movefile|addfile|delfile|version) /path/to/project [/path/to/(file|project)]"
-
-    type private Args =
-        | Template of string
-        | [<AltCommandLine("-fxv")>] FrameworkVersion of string
-        | Organisation of string
-        | Direction of string
-        | Repeat of int
-        | Link of string
-        | Compile of bool
-    with
-        interface IArgParserTemplate with
-            member s.Usage = 
-                match s with
-                | Template _ -> "init -- specify the template (library|console) [default: library]"
-                | FrameworkVersion _ -> "init -- specify the framework version (4.0|4.5|4.5.1) [default: 4.5]"
-                | Organisation _ -> "init -- specify the organisation"
-                | Direction _ -> "movefile -- specify the direction (down|up)"
-                | Repeat _ -> "movefile -- specify the distance [default: 1]"
-                | Link _ -> "addfile -- specify an optional Link attribute"
-                | Compile _ -> "addfile -- should the file be compiled or not  [default: true]"
-
-    let private templateArg (res : ArgParseResults<Args>) = res.TryGetResult(<@ Template @>) |> Template.Create
-
-    let private frameworkVersionArg (res : ArgParseResults<Args>) = res.TryGetResult(<@ FrameworkVersion @>) |> FrameworkVersion.Create
-
-    let private parseDirection s = s |> Direction.Create
-        
-    let private parser = UnionArgParser.Create<Args>()
-
-    let private (|Options|) (args : string list) =
-        let results = parser.Parse(List.toArray args)
-        results
-
-
-    let parse (ToList args) : Result<Operation> =
-        try
-            match args with
-            | [] -> 
-                parser.Usage commandUsage 
-                |> Failure
-
-            | ToLower "version" :: _ ->
-                Success Version
-
-            | ToLower "init" :: FullPath path :: Options opts -> 
-                let template = templateArg opts
-                let fxv = frameworkVersionArg opts
-                let org = 
-                    match opts.TryGetResult(<@ Organisation @>) with
-                    | Some org -> org
-                    | None -> "MyOrg"
-                ProjectInitData.create path (Some template) (Some fxv) (Some org) |> Init |> Success
-            
-            | ToLower "addfile" :: FullPath project :: FullPath file :: Options opts ->
-                let compile = opts.GetResult(<@ Compile @>, true)
-                AddFile { ProjPath = project
-                          FilePath = file
-                          Link = opts.TryGetResult <@ Link @>
-                          Compile = compile }
-                |> Success
-            
-            | [ToLower "delfile"; FullPath project; FullPath file] -> 
-                DelFile { ProjPath = project; FilePath = file }
-                |> Success
-            
-            | ToLower "movefile" :: FullPath project :: FullPath file :: Options opts
-                    when opts.Contains <@ Direction @> ->
-
-                let direction = opts.PostProcessResult(<@ Direction @>, parseDirection)
-                MoveFile { ProjPath = project
-                           FilePath = file
-                           Direction = direction
-                           Repeat = opts.GetResult(<@ Repeat @>, 1)}
-                |> Success
-            
-            | [ToLower "reference"; FullPath project; FullPath reference] -> 
-                Reference { ProjPath = project; Reference = reference } |> Success
-
-            | _ -> Failure (parser.Usage (sprintf "Error: '%s' is not a recognized command or received incorrect arguments.\n\n%s" args.Head commandUsage))
-        with
-        | :? System.ArgumentException as e ->
-                let lines = e.Message.Split([|'\n'|])
-                let msg = parser.Usage (sprintf "%s\n\n%s" lines.[0] commandUsage)
-                Failure msg
-

--- a/src/Projekt/Args.fs
+++ b/src/Projekt/Args.fs
@@ -1,111 +1,187 @@
 module Projekt.Args
 
 open Projekt.Types
-open System.IO
-open Nessos.UnionArgParser
 
-type private Args =
-    | Template of string
-    | [<AltCommandLine("-fxv")>] FrameworkVersion of string
-    | Organisation of string
-    | Direction of string
-    | Repeat of int
-    | Link of string
-    | Compile of bool
-with
-    interface IArgParserTemplate with
-        member s.Usage = 
-            match s with
-            | Template _ -> "init -- specify the template (library|console) [default: library]"
-            | Direction _ -> "movefile -- specify the direction (down|up)"
-            | Repeat _ -> "movefile -- specify the distance [default: 1]"
-            | FrameworkVersion _ -> "init -- specify the framework version (4.0|4.5|4.5.1) [default: 4.5]"
-            | Organisation _ -> "init -- specify the organisation"
-            | Link _ -> "addfile -- specify an optional Link attribute"
-            | Compile _ -> "addfile -- should the file be compiled or not  [default: true]"
+module NewArgs =
+    open CommandLine
 
-let private templateArg (res : ArgParseResults<Args>) =
-    match res.TryGetResult(<@ Template @>) with
-    | Some (ToLower "console") -> Console
-    | Some (ToLower "library") -> Library
-    | None -> Library
-    | _ -> failwith "invalid template argument specified"
+    [<Verb("init", HelpText = "create a new project")>]
+    type public InitOptions = {
+        [<Value(0, Required = true)>]   path : string 
+        [<Option(Default = "library")>] template : string
+        [<Option(Default = "4.5")>]       frameworkVersion : string
+        [<Option>]                      organization : string option
+    }
+    with 
+        member x.ToOperation =
+            match x.path with
+            | FullPath p -> 
+                ProjectInitData.create p (x.template |> Some |> Template.Create |> Some) (x.frameworkVersion |> Some |> FrameworkVersion.Create |> Some) x.organization
+                |> Init
+            | _ -> failwith "not given a full path"
 
-let private frameworkVersionArg (res : ArgParseResults<Args>) =
-    match res.TryGetResult(<@ FrameworkVersion @>) with
-    | Some "4.0" -> V4_0
-    | Some "4.5" -> V4_5 
-    | Some "4.5.1" -> V4_5_1
-    | None -> V4_5
-    | _ -> failwith "invalid framework version argument specified"
+    [<Verb("reference", HelpText = "reference a dll")>]
+    type public ReferenceOptions = {
+        [<Value(0, Required = true)>]   projectPath : string
+        [<Value(1, Required = true)>]   referencePath : string
+    }
+    with 
+        member x.ToOperation =
+            match x.projectPath, x.referencePath with
+            | FullPath project, FullPath reference -> {ProjPath = project; Reference = reference} |> Reference
+            | _,_ -> failwith "one or both paths were invalid"
 
-let private parseDirection s =
-    match s with
-    | ToLower "up" -> Up
-    | ToLower "down" -> Down
-    | _ -> failwith "invalid direction specified"
-
-let private parser = UnionArgParser.Create<Args>()
-
-let private (|Options|) (args : string list) =
-    let results = parser.Parse(List.toArray args)
-    results
-
-let (|FullPath|_|) (path : string) =
-    try 
-        Path.GetFullPath path |> Some
+    [<Verb("movefile", HelpText = "Move a file within a project")>]
+    type public MoveFileOptions = {
+        [<Value(0, Required = true)>]   projectPath : string
+        [<Value(1, Required = true)>]   filePath : string
+        [<Option(Required = true)>]     direction : string
+        [<Option(Default = 1)>]         repeat : int
+    }
     with
-    | _ -> None
+        member x.ToOperation =
+            match x.projectPath, x.filePath, Direction.Create x.direction with
+            | FullPath project, FullPath file, dir -> {ProjPath = project; FilePath = file; Direction = dir; Repeat = x.repeat} |> MoveFile
+            | _,_,_ -> failwith "invalid paths or direction"
 
-let commandUsage = "projekt (init|reference|movefile|addfile|delfile|version) /path/to/project [/path/to/(file|project)]"
+    [<Verb("addfile", HelpText = "Add a file to a project")>]
+    type public AddFileOptions = {
+        [<Value(0, Required = true)>]   projectPath : string
+        [<Value(1, Required = true)>]   filePath : string
+        [<Option>]                      link : string option
+        [<Option(Default = true)>]      compile : bool 
+    }
+    with 
+        member x.ToOperation =
+            match x.projectPath, x.filePath with
+            | FullPath project, FullPath file -> {ProjPath = project; FilePath = file; Link = x.link; Compile = x.compile} |> AddFile 
+            | _,_ -> failwith "invalid paths"
 
-let parse (ToList args) : Result<Operation> =
-    try
-        match args with
-        | [] -> 
-            parser.Usage commandUsage 
-            |> Failure
-
-        | ToLower "version" :: _ ->
-            Success Version
-
-        | ToLower "init" :: FullPath path :: Options opts -> 
-            let template = templateArg opts
-            let fxv = frameworkVersionArg opts
-            let org = 
-                match opts.TryGetResult(<@ Organisation @>) with
-                | Some org -> org
-                | None -> "MyOrg"
-            Init (ProjectInitData.create (path, template, fxv, org)) |> Success
-            
-        | ToLower "addfile" :: FullPath project :: FullPath file :: Options opts ->
-            let compile = opts.GetResult(<@ Compile @>, true)
-            AddFile { ProjPath = project
-                      FilePath = file
-                      Link = opts.TryGetResult <@ Link @>
-                      Compile = compile }
-            |> Success
-            
-        | [ToLower "delfile"; FullPath project; FullPath file] -> 
-            DelFile { ProjPath = project; FilePath = file }
-            |> Success
-            
-        | ToLower "movefile" :: FullPath project :: FullPath file :: Options opts
-                when opts.Contains <@ Direction @> ->
-
-            let direction = opts.PostProcessResult(<@ Direction @>, parseDirection)
-            MoveFile { ProjPath = project
-                       FilePath = file
-                       Direction = direction
-                       Repeat = opts.GetResult(<@ Repeat @>, 1)}
-            |> Success
-            
-        | [ToLower "reference"; FullPath project; FullPath reference] -> 
-            Reference { ProjPath = project; Reference = reference } |> Success
-
-        | _ -> Failure (parser.Usage (sprintf "Error: '%s' is not a recognized command or received incorrect arguments.\n\n%s" args.Head commandUsage))
+    [<Verb("delfile", HelpText = "Delete a file from a project")>]
+    type public DelFileOptions = {
+        [<Value(0, Required = true)>]   projectPath : string
+        [<Value(1, Required = true)>]   filePath : string
+    }
     with
-    | :? System.ArgumentException as e ->
-            let lines = e.Message.Split([|'\n'|])
-            let msg = parser.Usage (sprintf "%s\n\n%s" lines.[0] commandUsage)
-            Failure msg
+        member x.ToOperation =
+            match x.projectPath, x.filePath with
+            | FullPath project, FullPath file -> ({ProjPath = project; FilePath = file} : DelFileData) |> DelFile
+            | _,_ -> failwith "invalid paths"
+
+    [<Verb("version", HelpText = "Print out the version of this tool")>]
+    type public VersionOptions = {
+        [<Option>] noArg : string option
+    }
+    with 
+        member x.ToOperation = Version
+
+    let parse args = 
+        let parsed = CommandLine.Parser.Default.ParseArguments<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions, VersionOptions>(args)
+        // tried to get fancy here with a statically resolved type param to invoke the ToOperation member on the individal option cases, but I couldn't get it to work....
+
+        result {
+            try 
+                return 
+                    parsed.Return<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions, VersionOptions, Operation>(
+                        (fun (init : InitOptions) -> init.ToOperation), 
+                        (fun (ref : ReferenceOptions) -> ref.ToOperation), 
+                        (fun (mv : MoveFileOptions) -> mv.ToOperation), 
+                        (fun (add : AddFileOptions) -> add.ToOperation), 
+                        (fun (del : DelFileOptions) -> del.ToOperation), 
+                        (fun (ver : VersionOptions) -> ver.ToOperation), 
+                        (fun errs -> printfn "%A" errs; Operation.Exit)
+                    )
+            with
+                | _ -> return Operation.Exit
+        }
+        
+
+module OldArgs =
+    open Nessos.UnionArgParser
+
+    let commandUsage = "projekt (init|reference|movefile|addfile|delfile|version) /path/to/project [/path/to/(file|project)]"
+
+    type private Args =
+        | Template of string
+        | [<AltCommandLine("-fxv")>] FrameworkVersion of string
+        | Organisation of string
+        | Direction of string
+        | Repeat of int
+        | Link of string
+        | Compile of bool
+    with
+        interface IArgParserTemplate with
+            member s.Usage = 
+                match s with
+                | Template _ -> "init -- specify the template (library|console) [default: library]"
+                | FrameworkVersion _ -> "init -- specify the framework version (4.0|4.5|4.5.1) [default: 4.5]"
+                | Organisation _ -> "init -- specify the organisation"
+                | Direction _ -> "movefile -- specify the direction (down|up)"
+                | Repeat _ -> "movefile -- specify the distance [default: 1]"
+                | Link _ -> "addfile -- specify an optional Link attribute"
+                | Compile _ -> "addfile -- should the file be compiled or not  [default: true]"
+
+    let private templateArg (res : ArgParseResults<Args>) = res.TryGetResult(<@ Template @>) |> Template.Create
+
+    let private frameworkVersionArg (res : ArgParseResults<Args>) = res.TryGetResult(<@ FrameworkVersion @>) |> FrameworkVersion.Create
+
+    let private parseDirection s = s |> Direction.Create
+        
+    let private parser = UnionArgParser.Create<Args>()
+
+    let private (|Options|) (args : string list) =
+        let results = parser.Parse(List.toArray args)
+        results
+
+
+    let parse (ToList args) : Result<Operation> =
+        try
+            match args with
+            | [] -> 
+                parser.Usage commandUsage 
+                |> Failure
+
+            | ToLower "version" :: _ ->
+                Success Version
+
+            | ToLower "init" :: FullPath path :: Options opts -> 
+                let template = templateArg opts
+                let fxv = frameworkVersionArg opts
+                let org = 
+                    match opts.TryGetResult(<@ Organisation @>) with
+                    | Some org -> org
+                    | None -> "MyOrg"
+                ProjectInitData.create path (Some template) (Some fxv) (Some org) |> Init |> Success
+            
+            | ToLower "addfile" :: FullPath project :: FullPath file :: Options opts ->
+                let compile = opts.GetResult(<@ Compile @>, true)
+                AddFile { ProjPath = project
+                          FilePath = file
+                          Link = opts.TryGetResult <@ Link @>
+                          Compile = compile }
+                |> Success
+            
+            | [ToLower "delfile"; FullPath project; FullPath file] -> 
+                DelFile { ProjPath = project; FilePath = file }
+                |> Success
+            
+            | ToLower "movefile" :: FullPath project :: FullPath file :: Options opts
+                    when opts.Contains <@ Direction @> ->
+
+                let direction = opts.PostProcessResult(<@ Direction @>, parseDirection)
+                MoveFile { ProjPath = project
+                           FilePath = file
+                           Direction = direction
+                           Repeat = opts.GetResult(<@ Repeat @>, 1)}
+                |> Success
+            
+            | [ToLower "reference"; FullPath project; FullPath reference] -> 
+                Reference { ProjPath = project; Reference = reference } |> Success
+
+            | _ -> Failure (parser.Usage (sprintf "Error: '%s' is not a recognized command or received incorrect arguments.\n\n%s" args.Head commandUsage))
+        with
+        | :? System.ArgumentException as e ->
+                let lines = e.Message.Split([|'\n'|])
+                let msg = parser.Usage (sprintf "%s\n\n%s" lines.[0] commandUsage)
+                Failure msg
+

--- a/src/Projekt/Args.fs
+++ b/src/Projekt/Args.fs
@@ -4,6 +4,7 @@ open Projekt.Types
 
 module Args =
     open CommandLine
+    open CommandLine.Text
 
     [<Verb("init", HelpText = "create a new project")>]
     type InitOptions = 
@@ -24,9 +25,17 @@ module Args =
                     x.Organization) |> Init
 
             | _ -> failwith "not given a full path"
+        [<Usage(ApplicationAlias = "projekt")>]
+        static member Examples 
+            with get () = 
+                seq {
+                    yield Example("normal usage", {Path = @"c:\code\projekt\"; Template = ""; FrameworkVersion = ""; Organization = None})
+                    yield Example("make an exe project", {Path = @"c:\code\projekt\"; Template = "console"; FrameworkVersion = ""; Organization = None})
+                    yield Example("target .net 4.0", {Path = @"c:\code\projekt\"; Template = ""; FrameworkVersion = "4.0"; Organization = None})
+                }
 
     [<Verb("reference", HelpText = "reference another dependency in this project")>]
-    type ReferenceOptions = 
+    type private ReferenceOptions = 
         { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
           [<Value(1, Required = true, MetaName = "reference path")>] ReferencePath : string }
     with 
@@ -39,7 +48,7 @@ module Args =
             | _,_ -> failwith "one or both paths were invalid"
 
     [<Verb("movefile", HelpText = "Move a file within a project")>]
-    type MoveFileOptions = 
+    type private MoveFileOptions = 
         { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
           [<Value(1, Required = true, MetaName = "file path")>] FilePath : string
           [<Option(Required = true)>] direction : string
@@ -56,7 +65,7 @@ module Args =
             | _,_,_ -> failwith "invalid paths or direction"
 
     [<Verb("addfile", HelpText = "Add a file to a project")>]
-    type AddFileOptions = 
+    type private AddFileOptions = 
         { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
           [<Value(1, Required = true, MetaName = "file path")>] FilePath : string
           [<Option>] link : string option
@@ -73,7 +82,7 @@ module Args =
             | _,_ -> failwith "invalid paths"
 
     [<Verb("delfile", HelpText = "Delete a file from a project")>]
-    type DelFileOptions = 
+    type private DelFileOptions = 
         { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
           [<Value(1, Required = true, MetaName = "file path")>] FilePath : string   }
     with
@@ -87,8 +96,10 @@ module Args =
                 |> DelFile 
             | _,_ -> failwith "invalid paths"
 
+    let private parser = CommandLine.Parser.Default
+
     let parse args = 
-        let parsed = CommandLine.Parser.Default.ParseArguments<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions>(args)
+        let parsed = parser.ParseArguments<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions>(args)
         // tried to get fancy here with a statically resolved type param to invoke the ToOperation member on the individal option cases, but I couldn't get it to work....
 
         parsed.Return<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions, Result<Operation>>(

--- a/src/Projekt/Args.fs
+++ b/src/Projekt/Args.fs
@@ -80,7 +80,6 @@ module NewArgs =
         // tried to get fancy here with a statically resolved type param to invoke the ToOperation member on the individal option cases, but I couldn't get it to work....
 
         result {
-            try 
                 return 
                     parsed.Return<InitOptions, ReferenceOptions, MoveFileOptions, AddFileOptions, DelFileOptions, VersionOptions, Operation>(
                         (fun (init : InitOptions) -> init.ToOperation), 
@@ -91,8 +90,6 @@ module NewArgs =
                         (fun (ver : VersionOptions) -> ver.ToOperation), 
                         (fun errs -> printfn "%A" errs; Operation.Exit)
                     )
-            with
-                | _ -> return Operation.Exit
         }
         
 

--- a/src/Projekt/Args.fs
+++ b/src/Projekt/Args.fs
@@ -6,73 +6,85 @@ module Args =
     open CommandLine
 
     [<Verb("init", HelpText = "create a new project")>]
-    type public InitOptions = 
-        {   [<Value(0, Required = true, MetaName = "project path")>]    path : string 
-            [<Option(Default = "library")>]                             template : string
-            [<Option(Default = "4.5")>]                                 frameworkVersion : string
-            [<Option>]                                                  organization : string option    }
+    type InitOptions = 
+        { [<Value(0, Required = true, MetaName = "project path")>] Path : string 
+          [<Option(Default = "library")>] Template : string
+          [<Option(Default = "4.5")>] FrameworkVersion : string
+          [<Option>] Organization : string option }
     with 
         member x.ToOperation =
-            match x.path with
+            match x.Path with
             | FullPath p -> 
-                let template = x.template |> Template.Create |> Some
-                let frmwkVersion = x.frameworkVersion |> FrameworkVersion.Create |> Some
+                let template = x.Template |> Template.Create |> Some
+                let frmwkVersion = x.FrameworkVersion |> FrameworkVersion.Create |> Some
                 (ProjectInitData.create 
                     p 
                     template
                     frmwkVersion
-                    x.organization) |> Init
+                    x.Organization) |> Init
 
             | _ -> failwith "not given a full path"
 
     [<Verb("reference", HelpText = "reference a dll")>]
-    type public ReferenceOptions = 
-        {   [<Value(0, Required = true, MetaName = "project path")>]    projectPath : string
-            [<Value(1, Required = true, MetaName = "reference path")>]  referencePath : string  }
+    type ReferenceOptions = 
+        { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
+          [<Value(1, Required = true, MetaName = "reference path")>] ReferencePath : string }
     with 
         member x.ToOperation =
-            match x.projectPath, x.referencePath with
+            match x.ProjectPath, x.ReferencePath with
             | FullPath project, FullPath reference ->
-                {ProjPath = project; Reference = reference} |> Reference
+                { ProjPath = project
+                  Reference = reference }
+                |> Reference
             | _,_ -> failwith "one or both paths were invalid"
 
     [<Verb("movefile", HelpText = "Move a file within a project")>]
-    type public MoveFileOptions = 
-        {   [<Value(0, Required = true, MetaName = "project path")>]    projectPath : string
-            [<Value(1, Required = true, MetaName = "file path")>]       filePath : string
-            [<Option(Required = true)>]                                 direction : string
-            [<Option(Default = 1)>]                                     repeat : int    }
+    type MoveFileOptions = 
+        { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
+          [<Value(1, Required = true, MetaName = "file path")>] FilePath : string
+          [<Option(Required = true)>] direction : string
+          [<Option(Default = 1)>] repeat : int }
     with
         member x.ToOperation =
-            match x.projectPath, x.filePath, Direction.Create x.direction with
+            match x.ProjectPath, x.FilePath, Direction.Create x.direction with
             | FullPath project, FullPath file, dir -> 
-                {ProjPath = project; FilePath = file; Direction = dir; Repeat = x.repeat} |> MoveFile
+                { ProjPath = project
+                  FilePath = file
+                  Direction = dir
+                  Repeat = x.repeat }
+                |> MoveFile
             | _,_,_ -> failwith "invalid paths or direction"
 
     [<Verb("addfile", HelpText = "Add a file to a project")>]
-    type public AddFileOptions = 
-        {   [<Value(0, Required = true, MetaName = "project path")>]    projectPath : string
-            [<Value(1, Required = true, MetaName = "file path")>]       filePath : string
-            [<Option>]                                                  link : string option
-            [<Option(Default = true)>]                                  compile : bool  }
+    type AddFileOptions = 
+        { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
+          [<Value(1, Required = true, MetaName = "file path")>] FilePath : string
+          [<Option>] link : string option
+          [<Option(Default = true)>] compile : bool }
     with 
         member x.ToOperation =
-            match x.projectPath, x.filePath with
+            match x.ProjectPath, x.FilePath with
             | FullPath project, FullPath file -> 
-                {ProjPath = project; FilePath = file; Link = x.link; Compile = x.compile} |> AddFile 
+                { ProjPath = project
+                  FilePath = file
+                  Link = x.link
+                  Compile = x.compile } 
+                |> AddFile 
             | _,_ -> failwith "invalid paths"
 
     [<Verb("delfile", HelpText = "Delete a file from a project")>]
-    type public DelFileOptions = 
-        {   [<Value(0, Required = true, MetaName = "project path")>]    projectPath : string
-            [<Value(1, Required = true, MetaName = "file path")>]       filePath : string   }
+    type DelFileOptions = 
+        { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
+          [<Value(1, Required = true, MetaName = "file path")>] FilePath : string   }
     with
         member x.ToOperation =
-            match x.projectPath, x.filePath with
+            match x.ProjectPath, x.FilePath with
             | FullPath project, FullPath file -> 
                 // typing needed here because of the duplication between MoveFileData and DelFileData records
                 // TODO: maybe consolidate?
-                ({ProjPath = project; FilePath = file} : DelFileData) |> DelFile 
+                ({ ProjPath = project 
+                   FilePath = file } : DelFileData)
+                |> DelFile 
             | _,_ -> failwith "invalid paths"
 
     let parse args = 

--- a/src/Projekt/Args.fs
+++ b/src/Projekt/Args.fs
@@ -25,7 +25,7 @@ module Args =
 
             | _ -> failwith "not given a full path"
 
-    [<Verb("reference", HelpText = "reference a dll")>]
+    [<Verb("reference", HelpText = "reference another dependency in this project")>]
     type ReferenceOptions = 
         { [<Value(0, Required = true, MetaName = "project path")>] ProjectPath : string
           [<Value(1, Required = true, MetaName = "reference path")>] ReferencePath : string }

--- a/src/Projekt/AssemblyInfo.fs
+++ b/src/Projekt/AssemblyInfo.fs
@@ -8,6 +8,7 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyVersionAttribute("0.0.2")>]
 [<assembly: AssemblyFileVersionAttribute("0.0.2")>]
 [<assembly: InternalsVisibleToAttribute("Projekt.Tests")>]
+[<assembly: AssemblyCompanyAttribute("fsprojects")>]
 do ()
 
 module internal AssemblyVersionInformation =

--- a/src/Projekt/Main.fs
+++ b/src/Projekt/Main.fs
@@ -5,8 +5,14 @@ open System.Xml.Linq
 
 [<EntryPoint>]
 let main argv =
+    let newOp = 
+        match Args.NewArgs.parse argv with
+        | Success op -> op 
+        | Failure msg ->
+            eprintfn "%s" msg
+            Exit
     let op = 
-        match Args.parse argv with
+        match Args.OldArgs.parse argv with
         | Success op -> op 
         | Failure msg ->
             eprintfn "%s" msg

--- a/src/Projekt/Main.fs
+++ b/src/Projekt/Main.fs
@@ -6,10 +6,10 @@ open System.Xml.Linq
 [<EntryPoint>]
 let main argv =
     let newOp = 
-        match Args.NewArgs.parse argv with
+        match Args.Args.parse argv with
         | Success op -> op 
         | Failure _ -> Exit
-
+            
     let save (el : XElement) (path: string) =
         try
             el.Save path
@@ -53,10 +53,6 @@ let main argv =
         Project.addReference path reference
         |> saveOrPrintError path
 
-    | Version ->
-        printfn "projekt %s" AssemblyVersionInformation.Version
-        0
-          
     | _ -> 
         1
 

--- a/src/Projekt/Main.fs
+++ b/src/Projekt/Main.fs
@@ -8,15 +8,7 @@ let main argv =
     let newOp = 
         match Args.NewArgs.parse argv with
         | Success op -> op 
-        | Failure msg ->
-            eprintfn "%s" msg
-            Exit
-    let op = 
-        match Args.OldArgs.parse argv with
-        | Success op -> op 
-        | Failure msg ->
-            eprintfn "%s" msg
-            Exit
+        | Failure _ -> Exit
 
     let save (el : XElement) (path: string) =
         try
@@ -38,7 +30,7 @@ let main argv =
         if Directory.Exists cur then cur
         else eprintfn "Error: project template directory not found at '%s'" cur; exit 1
     
-    match op with
+    match newOp with
     | Init data ->
         match Template.init templatesDir data with
         | Success _ -> 0

--- a/src/Projekt/Projekt.fsproj
+++ b/src/Projekt/Projekt.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -36,30 +36,6 @@
     <DocumentationFile>.\bin\Release\Projekt.xml</DocumentationFile>
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Util.fs" />
-    <Compile Include="Types.fs" />
-    <Compile Include="Template.fs" />
-    <Compile Include="Args.fs" />
-    <Compile Include="XmlLinqHelpers.fs" />
-    <Compile Include="Project.fs" />
-    <Compile Include="Main.fs" />
-    <None Include="bootstrap.fsx" />
-    <None Include="paket.references" />
-    <None Include="paket.template" />
-  </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
@@ -81,16 +57,54 @@
   <Target Name="BeforeBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Templates Include="$(SolutionDir)\templates\**\*.*"/>
-  </ItemGroup>
   <Target Name="AfterBuild">
-    <Copy
-        SourceFiles="@(Templates)"
-        DestinationFolder="$(OutputPath)\templates\%(Templates.RecursiveDir)"
-        />
+    <Copy SourceFiles="@(Templates)" DestinationFolder="$(OutputPath)\templates\%(Templates.RecursiveDir)" />
   </Target>
   <Import Project="..\..\.paket\paket.targets" />
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Util.fs" />
+    <Compile Include="Types.fs" />
+    <Compile Include="Template.fs" />
+    <Compile Include="Args.fs" />
+    <Compile Include="XmlLinqHelpers.fs" />
+    <Compile Include="Project.fs" />
+    <Compile Include="Main.fs" />
+    <None Include="bootstrap.fsx" />
+    <None Include="paket.references" />
+    <None Include="paket.template" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="CommandLine">
+          <HintPath>..\..\packages\CommandLineParser\lib\net40\CommandLine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="CommandLine">
+          <HintPath>..\..\packages\CommandLineParser\lib\net45\CommandLine.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
       <ItemGroup>

--- a/src/Projekt/Projekt.fsproj
+++ b/src/Projekt/Projekt.fsproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="Template.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/Projekt/Projekt.fsproj
+++ b/src/Projekt/Projekt.fsproj
@@ -106,24 +106,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="UnionArgParser">
-          <HintPath>..\..\packages\UnionArgParser\lib\net35\UnionArgParser.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
-      <ItemGroup>
-        <Reference Include="UnionArgParser">
-          <HintPath>..\..\packages\UnionArgParser\lib\net40\UnionArgParser.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
 </Project>

--- a/src/Projekt/Template.targets
+++ b/src/Projekt/Template.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<ItemGroup>
+  <Templates Include="$(SolutionDir)\templates\**\*.*" />
+</ItemGroup>
+</Project>

--- a/src/Projekt/Types.fs
+++ b/src/Projekt/Types.fs
@@ -4,16 +4,37 @@ module Projekt.Types
 type Template =
     | Console
     | Library
+    with 
+        static member Create arg = 
+            match arg with
+            | Some (ToLower "console") -> Console
+            | Some (ToLower "library") -> Library
+            | None -> Library
+            | _ -> failwith "invalid template argument specified"
 
 type Direction =
     | Up
     | Down
+    with
+        static member Create arg =
+            match arg with
+            | ToLower "up" -> Up
+            | ToLower "down" -> Down
+            | _ -> failwith "invalid direction specified"
 
 type FrameworkVersion =
     | V4_0
     | V4_5
     | V4_5_1
 with 
+    static member Create arg = 
+        match arg with 
+        | Some "4.0" -> V4_0
+        | Some "4.5" -> V4_5 
+        | Some "4.5.1" -> V4_5_1
+        | None -> V4_5
+        | _ -> failwith "invalid framework version argument specified"
+
     override x.ToString () =
         match x with
         | V4_0 -> "4.0"
@@ -26,7 +47,7 @@ type ProjectInitData =
       FrameworkVersion: FrameworkVersion
       Organisation: string}
 with 
-    static member create (path, ?template, ?fxversion, ?org) =
+    static member create path template fxversion org =
         { ProjPath = path
           Template = defaultArg template Library
           FrameworkVersion = defaultArg fxversion V4_5

--- a/src/Projekt/Types.fs
+++ b/src/Projekt/Types.fs
@@ -7,9 +7,9 @@ type Template =
     with 
         static member Create arg = 
             match arg with
-            | Some (ToLower "console") -> Console
-            | Some (ToLower "library") -> Library
-            | None -> Library
+            | ToLower "console" -> Console
+            | ToLower "library" -> Library
+            | "" -> Library
             | _ -> failwith "invalid template argument specified"
 
 type Direction =
@@ -29,10 +29,10 @@ type FrameworkVersion =
 with 
     static member Create arg = 
         match arg with 
-        | Some "4.0" -> V4_0
-        | Some "4.5" -> V4_5 
-        | Some "4.5.1" -> V4_5_1
-        | None -> V4_5
+        | "4.0" -> V4_0
+        | "4.5" -> V4_5 
+        | "4.5.1" -> V4_5_1
+        | "" -> V4_5
         | _ -> failwith "invalid framework version argument specified"
 
     override x.ToString () =
@@ -80,7 +80,6 @@ type Operation =
     | DelFile of DelFileData
     | MoveFile of MoveFileData
     | Exit
-    | Version
 
 type Result<'a> =
     | Success of 'a

--- a/src/Projekt/Util.fs
+++ b/src/Projekt/Util.fs
@@ -2,13 +2,22 @@
 module Projekt.Util
 
 open System
+open System.IO
 
 let (|ToLower|) (s: string) =
     s.ToLowerInvariant()
 
 let (|ToList|) = Seq.toList 
 
+let (|FullPath|_|) (path : string) =
+        try 
+            Path.GetFullPath path |> Some
+        with
+        | _ -> None
+
 let (</>) a b = System.IO.Path.Combine(a,b)
+
+let csfunc f = System.Func<_,_>(f)
 
 let makeRelativePath (source: string) (target: string) =
     let source =

--- a/src/Projekt/paket.references
+++ b/src/Projekt/paket.references
@@ -1,2 +1,1 @@
-UnionArgParser
 CommandLineParser

--- a/src/Projekt/paket.references
+++ b/src/Projekt/paket.references
@@ -1,1 +1,2 @@
 UnionArgParser
+CommandLineParser

--- a/tests/Projekt.Tests/Projekt.Tests.fsproj
+++ b/tests/Projekt.Tests/Projekt.Tests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -56,30 +56,6 @@
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Tests.fs" />
-    <None Include="paket.references" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Projekt\Projekt.fsproj">
-      <Name>Projekt</Name>
-      <Project>{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}</Project>
-      <Private>True</Private>
-    </ProjectReference>
-  </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -109,6 +85,25 @@
     </When>
   </Choose>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Tests.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <ProjectReference Include="..\..\src\Projekt\Projekt.fsproj">
+      <Name>Projekt</Name>
+      <Project>{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}</Project>
+      <Private>True</Private>
+    </ProjectReference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/tests/Projekt.Tests/Projekt.Tests.fsproj
+++ b/tests/Projekt.Tests/Projekt.Tests.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -56,18 +56,10 @@
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Import Project="..\..\.paket\paket.targets" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Tests.fs" />
-    <None Include="App.config" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -79,12 +71,23 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Projekt\Projekt.fsproj">
       <Name>Projekt</Name>
       <Project>{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}</Project>
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\..\.paket\paket.targets" />
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5')">
       <ItemGroup>

--- a/tests/Projekt.Tests/Projekt.Tests.fsproj
+++ b/tests/Projekt.Tests/Projekt.Tests.fsproj
@@ -64,6 +64,27 @@
   </Target>
   -->
   <Import Project="..\..\.paket\paket.targets" />
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Tests.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <ProjectReference Include="..\..\src\Projekt\Projekt.fsproj">
+      <Name>Projekt</Name>
+      <Project>{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5')">
       <ItemGroup>
@@ -85,25 +106,6 @@
     </When>
   </Choose>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Tests.fs" />
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-    <ProjectReference Include="..\..\src\Projekt\Projekt.fsproj">
-      <Name>Projekt</Name>
-      <Project>{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}</Project>
-      <Private>True</Private>
-    </ProjectReference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/tests/Projekt.Tests/Projekt.Tests.fsproj
+++ b/tests/Projekt.Tests/Projekt.Tests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -56,10 +56,18 @@
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="..\..\.paket\paket.targets" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Tests.fs" />
-    <None Include="paket.references" />
+    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -71,23 +79,12 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Projekt\Projekt.fsproj">
       <Name>Projekt</Name>
       <Project>{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}</Project>
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Import Project="..\..\.paket\paket.targets" />
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5')">
       <ItemGroup>

--- a/tests/Projekt.Tests/Tests.fs
+++ b/tests/Projekt.Tests/Tests.fs
@@ -465,15 +465,3 @@ let ``moveFile down 2`` () =
 </Project>
 """
         assertDeepEquals expected result
-
-module Parsing =
-    let lines = [
-       "init C:\code" 
-    ]
-        
-    [<TestCaseSource("lines")>]
-    let ``old and new parsers should be equivalent`` (inputline : string) =
-        let splits = inputline.Split(' ');
-        let oldVersion = Args.OldArgs.parse splits
-        let newVersion = Args.NewArgs.parse splits
-        Assert.AreEqual(oldVersion, newVersion)

--- a/tests/Projekt.Tests/Tests.fs
+++ b/tests/Projekt.Tests/Tests.fs
@@ -465,3 +465,15 @@ let ``moveFile down 2`` () =
 </Project>
 """
         assertDeepEquals expected result
+
+module Parsing =
+    let lines = [
+       "init C:\code" 
+    ]
+        
+    [<TestCaseSource("lines")>]
+    let ``old and new parsers should be equivalent`` (inputline : string) =
+        let splits = inputline.Split(' ');
+        let oldVersion = Args.OldArgs.parse splits
+        let newVersion = Args.NewArgs.parse splits
+        Assert.AreEqual(oldVersion, newVersion)


### PR DESCRIPTION
I took a pass at unifying the command line args according to issue #27 .  I think CommandLine.Parser will work better for this case, due to the command -> verb -> options pattern this utility has.

I added a basic test that verifies that the new implementation is equivalent to the old implementation, but what I'd really like to do is write an FsCheck test that uses the Operation type to generate a command line string via the old parser, and then parse that string using the new parser and compare the resulting Operations.
