### PR TITLE
add listfiles option

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -38,7 +38,7 @@ help text below lists the commands and the various command-specific
 arguments.
 
     [lang=batch]
-    projekt (init|reference|movefile|addfile|delfile|version) /path/to/project [/path/to/(file|project)]
+    projekt (init|reference|movefile|addfile|delfile|listfiles|version) /path/to/project [/path/to/(file|project)]
 
             --template <string>: init -- specify the template (library|console) [default: library]
             --frameworkversion [-fxv] <string>: init -- specify the framework version (4.0|4.5|4.5.1) [default: 4.5]
@@ -76,12 +76,21 @@ project. To move the file `MyFile.fs` up by two, use:
     [lang=batch]
     <path to projekt>/projekt movefile MyProject.fsproj MyFile.fs --direction up --repeat 2
 
+#### List the order of files in a project
+
+The order of compilation is important in F# projects. This command lets you
+see the current ordering of files in the project. To see the order of files in
+`MyProject.fsproj`, use:
+
+    [lang=batch]
+    <path to projekt>/projekt listfiles MyProject.fsproj
+
 #### Reference another project
 
 Use the `reference` command:
 
     [lang=batch]
-    <path to projekt>/projekt reference MyProject.fsproj ../AnotherProject/AnotherProject.fsproj 
+    <path to projekt>/projekt reference MyProject.fsproj ../AnotherProject/AnotherProject.fsproj
 
 ## Contributing and copyright
 

--- a/src/Projekt/Main.fs
+++ b/src/Projekt/Main.fs
@@ -54,7 +54,7 @@ let main argv =
     | ListFiles data ->
         match (Project.listFiles data.ProjPath) with
         | Success files ->
-            List.iter (fun file -> eprintfn "%s" file) files
+            List.iter (fun file -> printfn "%s" file) files
             0
         | Failure msg ->
             eprintfn "%s" msg

--- a/src/Projekt/Main.fs
+++ b/src/Projekt/Main.fs
@@ -5,9 +5,9 @@ open System.Xml.Linq
 
 [<EntryPoint>]
 let main argv =
-    let op = 
+    let op =
         match Args.parse argv with
-        | Success op -> op 
+        | Success op -> op
         | Failure msg ->
             eprintfn "%s" msg
             Exit
@@ -31,7 +31,7 @@ let main argv =
         let cur = exeDir </> "templates"
         if Directory.Exists cur then cur
         else eprintfn "Error: project template directory not found at '%s'" cur; exit 1
-    
+
     match op with
     | Init data ->
         match Template.init templatesDir data with
@@ -50,7 +50,16 @@ let main argv =
     | MoveFile data ->
         (Project.moveFile data.ProjPath data.FilePath data.Direction data.Repeat)
         |> saveOrPrintError data.ProjPath
-        
+
+    | ListFiles data ->
+        match (Project.listFiles data.ProjPath) with
+        | Success files ->
+            List.iter (fun file -> eprintfn "%s" file) files
+            0
+        | Failure msg ->
+            eprintfn "%s" msg
+            1
+
     | Reference { ProjPath = path; Reference = reference } ->
         Project.addReference path reference
         |> saveOrPrintError path
@@ -58,7 +67,6 @@ let main argv =
     | Version ->
         printfn "projekt %s" AssemblyVersionInformation.Version
         0
-          
-    | _ -> 
-        1
 
+    | _ ->
+        1

--- a/src/Projekt/Types.fs
+++ b/src/Projekt/Types.fs
@@ -13,7 +13,7 @@ type FrameworkVersion =
     | V4_0
     | V4_5
     | V4_5_1
-with 
+with
     override x.ToString () =
         match x with
         | V4_0 -> "4.0"
@@ -25,7 +25,7 @@ type ProjectInitData =
       Template: Template
       FrameworkVersion: FrameworkVersion
       Organisation: string}
-with 
+with
     static member create (path, ?template, ?fxversion, ?org) =
         { ProjPath = path
           Template = defaultArg template Library
@@ -41,7 +41,7 @@ type AddFileData =
       FilePath: string
       Link: Option<string>
       Compile: bool }
-    
+
 type DelFileData =
     { ProjPath: string
       FilePath: string }
@@ -52,12 +52,16 @@ type MoveFileData =
       Direction: Direction
       Repeat: int }
 
+type ProjectLocationData =
+    { ProjPath: string }
+
 type Operation =
-    | Init of ProjectInitData //project path 
+    | Init of ProjectInitData //project path
     | Reference of ProjectReferenceData
     | AddFile of AddFileData
     | DelFile of DelFileData
     | MoveFile of MoveFileData
+    | ListFiles of ProjectLocationData
     | Exit
     | Version
 
@@ -102,5 +106,3 @@ type ResultBuilder() =
             x.While(enum.MoveNext,
                 x.Delay(fun () -> body enum.Current)))
 let result = ResultBuilder()
-
-

--- a/tests/Projekt.Tests/Tests.fs
+++ b/tests/Projekt.Tests/Tests.fs
@@ -40,7 +40,7 @@ let singleIGandTestRef = """<?xml version="1.0" encoding="utf-8"?>
     </ProjectReference>
   </ItemGroup>
 </Project>
-""" 
+"""
 
 [<Test>]
 let ``hasProjectReferenceWithInclude should find`` () =
@@ -48,15 +48,15 @@ let ``hasProjectReferenceWithInclude should find`` () =
     Project.hasProjectReferenceWithInclude "../../src/Test/Test.fsproj" sut
     |> Assert.IsTrue
 
-[<Test>] 
+[<Test>]
 let ``addProjRefNode should append an ItemGroup if none found`` () =
-    let expected = XElement.Parse singleIGandTestRef 
+    let expected = XElement.Parse singleIGandTestRef
     let guid = Guid.Parse "{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}"
     let sut = XElement.Parse baseXml
     let (Success result) = Project.addProjRefNode "../../src/Test/Test.fsproj" "Test" guid sut
     assertDeepEquals expected result
 
-[<Test>] 
+[<Test>]
 let ``addProjRefNode should append a ProjectReference if one already exists`` () =
     let expected = """<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -77,7 +77,7 @@ let ``addProjRefNode should append a ProjectReference if one already exists`` ()
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-</Project>""" 
+</Project>"""
 
     let expected = XElement.Parse expected
     let guid = Guid.Parse "{ceb3e6b3-c06f-4a24-82e6-9e70ba4adfe8}"
@@ -85,10 +85,10 @@ let ``addProjRefNode should append a ProjectReference if one already exists`` ()
     let (Success result) = Project.addProjRefNode "../../src/Test2/Test2.fsproj" "Test2" guid sut
     assertDeepEquals expected result
 
-[<Test>] 
+[<Test>]
 let ``addProjRefNode should be idempotent`` () =
-    let expected = XElement.Parse singleIGandTestRef 
-    let sut = XElement.Parse singleIGandTestRef 
+    let expected = XElement.Parse singleIGandTestRef
+    let sut = XElement.Parse singleIGandTestRef
     let guid = Guid.Parse "{165a6853-05ed-4f03-a7b1-1c84d4f01bf5}"
     let (Success result) = Project.addProjRefNode "../../src/Test/Test.fsproj" "Test" guid sut
     assertDeepEquals expected result
@@ -122,7 +122,7 @@ let ``addFile should create the file if it doesn't exist`` () =
     | Success result ->
         Assert.That(File.Exists srcFile, "File should exist: " + srcFile)
         File.Delete srcFile
-    
+
 [<Test>]
 let ``addFile should create an item group if not present`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-NoItemGroup-input.fsproj"
@@ -176,7 +176,7 @@ let ``addFile should insert the link`` () =
     | Success result ->
         let expected = XElement.Load (__SOURCE_DIRECTORY__ + "/data/AddFile-Link-expected.fsproj")
         assertDeepEquals expected result
-    
+
 [<Test>]
 let ``addFile followed by delFile should be identity`` () =
     let projFile = __SOURCE_DIRECTORY__ + "/data/AddFile-input.fsproj"
@@ -232,7 +232,7 @@ let ``delFile should remove file if present`` () =
     | Success result ->
         let expected = XElement.Parse delExpected
         assertDeepEquals expected result
-        
+
 [<Test>]
 let ``delFile should fail if not present`` () =
     let proj = XElement.Parse delInput
@@ -465,3 +465,25 @@ let ``moveFile down 2`` () =
 </Project>
 """
         assertDeepEquals expected result
+
+let listInput = """<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Compile Include="File1.fs" />
+    <Compile Include="File2.fs" />
+    <None Include="File3.fs" />
+    <Compile Include="File4.fs" />
+    <Compile Include="File5.fs" />
+    <Compile Include="File6.fs" />
+  </ItemGroup>
+</Project>
+"""
+
+[<Test>]
+let ``list files`` () =
+    let proj = XElement.Parse listInput
+    match Project.listFilesInProj proj with
+    | Failure s -> Assert.Fail s
+    | Success result ->
+        let expected = ["File1.fs" ; "File2.fs" ; "File3.fs" ; "File4.fs" ; "File5.fs" ; "File6.fs"]
+        Assert.AreEqual (expected, result)


### PR DESCRIPTION
I would like to use Projekt such that I rarely have to view or edit a raw .fsproj.  But I need to know the current build order to make effective use of the movefile command.  At present this requires me to view the .fsproj, so I might as well move the items around by hand at that point.  This change adds a "listfiles" option which lists all the Included files in the project to the shell, thus providing the data I need to understand my current build order (without showing me the other content in the .fsproj).
