### PR TITLE
Don't copy FSharp.Core.dll to output directory in Library template.

### DIFF
--- a/templates/Library/Library.fsproj
+++ b/templates/Library/Library.fsproj
@@ -33,9 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib"/>
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="System"/>
     <Reference Include="System.Core"/>
     <Reference Include="System.Numerics"/>


### PR DESCRIPTION
Per https://fsharp.github.io/2015/04/18/fsharp-core-notes.html#do-not-bundle-fsharpcore-with-a-library
